### PR TITLE
feat: enable turborepo remote cache

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -2,22 +2,45 @@
   "$schema": "https://turborepo.com/schema.json",
   "ui": "tui",
   "globalEnv": ["NODE_ENV", "API_BASE_URL"],
+  "remoteCache": {
+    "enabled": true,
+    "signature": true,
+    "timeout": 30,
+    "uploadTimeout": 60
+  },
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
-      "inputs": ["$TURBO_DEFAULT$", ".env*"],
-      "outputs": [".next/**", "!.next/cache/**"]
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        ".env*",
+        "src/**",
+        "public/**",
+        "!**/*.md",
+        "!**/*.test.{ts,tsx}"
+      ],
+      "outputs": [".next/**", "!.next/cache/**"],
+      "env": ["NEXT_PUBLIC_*"]
     },
     "lint": {
-      "dependsOn": ["^lint"]
+      "dependsOn": ["^lint"],
+      "outputs": [],
+      "cache": true
     },
     "check-types": {
-      "dependsOn": ["^check-types"]
+      "dependsOn": ["^check-types"],
+      "outputs": [],
+      "cache": true
     },
     "test": {
       "dependsOn": ["^test"],
-      "inputs": ["$TURBO_DEFAULT$", "**/*.test.{ts,tsx}", "**/*.spec.{ts,tsx}"],
-      "outputs": ["coverage/**"]
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "**/*.test.{ts,tsx}",
+        "**/*.spec.{ts,tsx}"
+      ],
+      "outputs": ["coverage/**"],
+      "cache": true
     },
     "test:watch": {
       "cache": false,
@@ -25,7 +48,8 @@
     },
     "test:coverage": {
       "dependsOn": ["^test:coverage"],
-      "outputs": ["coverage/**"]
+      "outputs": ["coverage/**"],
+      "cache": true
     },
     "dev": {
       "cache": false,


### PR DESCRIPTION
Enable Vercel Remote Cache to speed up builds and share cache across team and CI/CD.

Changes:
- Add remoteCache configuration with signature verification
- Optimize build task inputs to exclude unnecessary files
- Enable cache for lint, check-types, test, and test:coverage tasks
- Add explicit env variable tracking for NEXT_PUBLIC_* vars

Benefits:
- 10-100x faster builds when cache hits
- Team members can share build artifacts
- CI/CD deploys will be significantly faster
- 7-day artifact retention on Vercel

References:
- https://turborepo.com/repo/docs/core-concepts/remote-caching
- https://vercel.com/docs/monorepos/remote-caching