### PR TITLE
refactor(website): centralize Next.js dependencies to shared package

### DIFF
--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -15,17 +15,15 @@
   "dependencies": {
     "@radix-ui/react-accordion": "1.2.2",
     "@radix-ui/react-slot": "^1.2.3",
+    "@repo/next-config": "workspace:*",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "framer-motion": "^12.23.22",
     "lucide-react": "^0.454.0",
     "motion": "^12.23.22",
-    "next": "^15.5.0",
     "next-intl": "^4.0.0",
     "posthog-js": "^1.268.6",
     "posthog-node": "^5.9.1",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
     "tailwind-merge": "^2.5.5",
     "tailwindcss": "^3.4.4"
   },
@@ -44,8 +42,11 @@
     "eslint-config-next": "^15.5.0",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
+    "next": "^15.5.0",
     "postcss": "^8.5.3",
     "prettier": "^3.3.3",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
     "typescript": "^5.5.3"
   },
   "prettier": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       '@radix-ui/react-slot':
         specifier: ^1.2.3
         version: 1.2.3(@types/react@19.1.0)(react@19.1.1)
+      '@repo/next-config':
+        specifier: workspace:*
+        version: link:../../packages/next-config
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -65,9 +68,6 @@ importers:
       motion:
         specifier: ^12.23.22
         version: 12.23.22(@emotion/is-prop-valid@0.8.8)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      next:
-        specifier: ^15.5.0
-        version: 15.5.3(@babel/core@7.28.4)(@playwright/test@1.55.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       next-intl:
         specifier: ^4.0.0
         version: 4.3.9(next@15.5.3(@babel/core@7.28.4)(@playwright/test@1.55.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)(typescript@5.9.2)
@@ -77,12 +77,6 @@ importers:
       posthog-node:
         specifier: ^5.9.1
         version: 5.9.1
-      react:
-        specifier: ^19.0.0
-        version: 19.1.1
-      react-dom:
-        specifier: ^19.0.0
-        version: 19.1.1(react@19.1.1)
       tailwind-merge:
         specifier: ^2.5.5
         version: 2.6.0
@@ -132,12 +126,21 @@ importers:
       jest-environment-jsdom:
         specifier: ^29.7.0
         version: 29.7.0
+      next:
+        specifier: ^15.5.0
+        version: 15.5.3(@babel/core@7.28.4)(@playwright/test@1.55.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       postcss:
         specifier: ^8.5.3
         version: 8.5.6
       prettier:
         specifier: ^3.3.3
         version: 3.6.2
+      react:
+        specifier: ^19.1.0
+        version: 19.1.1
+      react-dom:
+        specifier: ^19.1.0
+        version: 19.1.1(react@19.1.1)
       typescript:
         specifier: ^5.5.3
         version: 5.9.2


### PR DESCRIPTION
## Summary
Phase 1 of monorepo dependency centralization - moving Next.js dependencies to shared package `@repo/next-config`.

### Changes
- **Moved from dependencies to devDependencies**: `next`, `react`, `react-dom`
- **Added**: `@repo/next-config` workspace package
- **Rationale**: Centralize Next.js version management across all apps in the monorepo

### Why devDependencies?
To maintain TypeScript type resolution while using the shared package for runtime dependencies.

### Test Results
✅ Type check: Passed  
✅ Build: Successful  
✅ Lint: Passed  

### Next Steps
- Phase 2: Centralize ESLint dependencies
- Phase 3: Centralize Tailwind CSS dependencies